### PR TITLE
Improve parallel performance

### DIFF
--- a/src/nexus_driver.F90
+++ b/src/nexus_driver.F90
@@ -59,6 +59,8 @@ program NEXUS_driver
   ReGridFile = ""
   OutputFile = ""
 
+  debugLevel = 0
+
   localrc = ESMF_SUCCESS
 
   if (localPet == 0) then

--- a/src/nexus_driver.F90
+++ b/src/nexus_driver.F90
@@ -23,7 +23,7 @@ program NEXUS_driver
   integer :: localPet
   integer :: idx, ind, item
   integer :: debugLevel
-  integer :: ibuf(1)
+  integer :: ibuf(2)
   character(ESMF_MAXSTR) :: ConfigFile
   character(ESMF_MAXSTR) :: ReGridFile
   character(ESMF_MAXSTR) :: OutputFile
@@ -97,7 +97,7 @@ program NEXUS_driver
 
   ibuf(1) = localrc
   ibuf(2) = debugLevel
-  call ESMF_VMBroadcast(vm, ibuf, 2, rootPet, rc=rc)
+  call ESMF_VMBroadcast(vm, ibuf, size(ibuf), rootPet, rc=rc)
   if (ESMF_LogFoundError(rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__,  &
     file=__FILE__)) &
@@ -112,7 +112,7 @@ program NEXUS_driver
   sbuf(1) = ConfigFile
   sbuf(2) = ReGridFile
   sbuf(3) = OutputFile
-  call ESMF_VMBroadcast(vm, sbuf, 2*len(sbuf(1)), rootPet, rc=rc)
+  call ESMF_VMBroadcast(vm, sbuf, size(sbuf)*len(sbuf(1)), rootPet, rc=rc)
   if (ESMF_LogFoundError(rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__,  &
     file=__FILE__)) &


### PR DESCRIPTION
This PR introduces updates aimed at improving performance and reducing memory footprint of parallel NEXUS runs.

It features:
- full decomposition of HEMCO's original standalone grid over parallel MPI tasks
- bug fixes affecting NEXUS initialization.

Note that while parallel results obtained with different number of tasks are bit-per-bit identical, they may differ slightly from results of serial runs. This is due to logic in legacy GEOS interpolation subroutines, which will skip interpolation if the destination grid matches the emission input grid.
