### PR TITLE
Fix time prints in concat script

### DIFF
--- a/utils/python/concatenate_nexus_post_split.py
+++ b/utils/python/concatenate_nexus_post_split.py
@@ -5,13 +5,13 @@ after make-pretty has been run on each split job output file.
 """
 
 
-def cdt_fmt(cdt):
-    """Convert cftime datetime to string."""
-    Y = cdt.year
-    m = cdt.month
-    d = cdt.day
-    H = cdt.hour
-    M = cdt.minute
+def dt_fmt(dt):
+    """Convert (cftime) datetime to string."""
+    Y = dt.year
+    m = dt.month
+    d = dt.day
+    H = dt.hour
+    M = dt.minute
     return f"{Y:04d}-{m:02d}-{d:02d} {H:02d}:{M:02d}"
 
 
@@ -47,7 +47,7 @@ def main(ifp, ofp):
         # ^ by default these are `cftime.DatetimeGregorian`s
         #   the pretty files currently don't have calendar set
         print(len(times_dt), "times")
-        print(f"first: {cdt_fmt(times_dt[0])}, last: {cdt_fmt(times_dt[-1])}")
+        print(f"first: {dt_fmt(times_dt[0])}, last: {dt_fmt(times_dt[-1])}")
 
         for i, t in enumerate(times_dt):
             time2files[t].append((f, i))
@@ -58,7 +58,7 @@ def main(ifp, ofp):
     time2files_unique = {}
     for t, locs in sorted(time2files.items()):
         if len(locs) > 1:
-            print(f"{cdt_fmt(t)} appears more than once")
+            print(f"{dt_fmt(t)} appears more than once")
             for f, i in locs:
                 print(f"- {f} time {i}")
         time2files_unique[t] = locs[-1]  # take last one (later simulation)
@@ -81,7 +81,7 @@ def main(ifp, ofp):
         inds = np.where(dt != dt_min)[0]
         for i in inds:
             print(
-                f"- time {i} ({cdt_fmt(time[i])}) to {i+1} ({cdt_fmt(time[i+1])})"
+                f"- time {i} ({dt_fmt(time[i])}) to {i+1} ({dt_fmt(time[i+1])})"
                 f" has dt {dt[i]}"
             )
 

--- a/utils/python/concatenate_nexus_post_split.py
+++ b/utils/python/concatenate_nexus_post_split.py
@@ -5,6 +5,16 @@ after make-pretty has been run on each split job output file.
 """
 
 
+def cdt_fmt(cdt):
+    """Convert cftime datetime to string."""
+    Y = cdt.year
+    m = cdt.month
+    d = cdt.day
+    H = cdt.hour
+    M = cdt.minute
+    return f"{Y:04d}-{m:02d}-{d:02d} {H:02d}:{M:02d}"
+
+
 def main(ifp, ofp):
     """
     Parameters
@@ -37,7 +47,7 @@ def main(ifp, ofp):
         # ^ by default these are `cftime.DatetimeGregorian`s
         #   the pretty files currently don't have calendar set
         print(len(times_dt), "times")
-        print(f"first: {times_dt[0]:%Y-%m-%d %H:%M}, last: {times_dt[-1]:%Y-%m-%d %H:%M}")
+        print(f"first: {cdt_fmt(times_dt[0])}, last: {cdt_fmt(times_dt[-1])}")
 
         for i, t in enumerate(times_dt):
             time2files[t].append((f, i))
@@ -48,7 +58,7 @@ def main(ifp, ofp):
     time2files_unique = {}
     for t, locs in sorted(time2files.items()):
         if len(locs) > 1:
-            print(f"{t:%Y-%m-%d %H:%M} appears more than once")
+            print(f"{cdt_fmt(t)} appears more than once")
             for f, i in locs:
                 print(f"- {f} time {i}")
         time2files_unique[t] = locs[-1]  # take last one (later simulation)
@@ -71,7 +81,7 @@ def main(ifp, ofp):
         inds = np.where(dt != dt_min)[0]
         for i in inds:
             print(
-                f"- time {i} ({time[i]:%Y-%m-%d %H:%M}) to {i+1} ({time[i+1]:%Y-%m-%d %H:%M})"
+                f"- time {i} ({cdt_fmt(time[i])}) to {i+1} ({cdt_fmt(time[i+1])})"
                 f" has dt {dt[i]}"
             )
 


### PR DESCRIPTION
On WCOSS, @JianpingHuang-NOAA got an error like this while testing @bbakernoaa 's [new workflow branch](https://github.com/bbakernoaa/ufs-srweather-app/tree/production/AQM.v7_biofix). 
```
/lfs/h2/emc/ptmp/jianping.huang/emc.para/com/aqm/v7.0/c79.20230525/00/NEXUS/aqm.t00z.NEXUS_Expt_split.00.nc
3 times
Traceback (most recent call last):
  File "/lfs/h2/emc/physics/noscrub/jianping.huang/nwdev/packages/aqm.v7.0.79/sorc/arl_nexus/utils/python/concatenate_nexus_post_split.py", line 173, in <module>
    raise SystemExit(main(**parse_args()))
  File "/lfs/h2/emc/physics/noscrub/jianping.huang/nwdev/packages/aqm.v7.0.79/sorc/arl_nexus/utils/python/concatenate_nexus_post_split.py", line 40, in main
    print(f"first: {times_dt[0]:%Y-%m-%d %H:%M}, last: {times_dt[-1]:%Y-%m-%d %H:%M}")
TypeError: unsupported format string passed to cftime._cftime.DatetimeGregorian.__format__
```
(though it worked fine on Hera)

This PR replaces the f-string formatting by a function, which should work the same but avoid that error (probably cftime is older on WCOSS workflow env than Hera).