### PR TITLE
AQMv7 EE2 compliance: add-ftrapuv and -check all into DEBUG builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
 set(HEMCO_EXTERNAL_CONFIG TRUE)
 set(GCCLASSIC_WRAPPER TRUE)
 
+string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
+if(UPPER_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+  set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -ftrapuv -check all")
+endif()
+
 # add project's subdirectories
 add_subdirectory(HEMCO)
 add_subdirectory(src)


### PR DESCRIPTION
This PR updates the CMAKE_Fortran_FLAGS_DEBUG to allow upstream changes, this spefically allows ufs-srweather-app to send -ftrapuv and -check all down to NEXUS to meet NCO EE2 compliance.