### PR TITLE
CLI option to write restart file in NEXUS mode

### DIFF
--- a/src/nexus_driver.F90
+++ b/src/nexus_driver.F90
@@ -14,6 +14,7 @@ program NEXUS_driver
       "--regrid-to  ", "r:           ", &
       "-d           ", "d            ", &
       "--debug      ", "d            ", &
+      "--wr         ", "wr           ", &
       "-o           ", "o:           ", &
       "--output     ", "o:           "  &
     /), (/ 9, 2 /), order=(/ 2, 1 /))
@@ -23,6 +24,7 @@ program NEXUS_driver
   integer :: localPet
   integer :: idx, ind, item
   integer :: debugLevel
+  logical :: writeRestart
   integer :: ibuf(2)
   character(ESMF_MAXSTR) :: ConfigFile
   character(ESMF_MAXSTR) :: ReGridFile
@@ -60,6 +62,7 @@ program NEXUS_driver
   OutputFile = ""
 
   debugLevel = 0
+  writeRestart = .false.
 
   localrc = ESMF_SUCCESS
 
@@ -88,6 +91,8 @@ program NEXUS_driver
             OutputFile = optarg
           case ("d")
             debugLevel = 1
+          case ("wr")
+            writeRestart = .true.
           case ("h")
           case default
         end select
@@ -124,7 +129,7 @@ program NEXUS_driver
   ! ----------------------------------------------------------------------------
   !   Initialize NEXUS
   ! ----------------------------------------------------------------------------
-  call NEXUS_Initialize( ConfigFile, ReGridFile, OutputFile, debugLevel, rc=rc )
+  call NEXUS_Initialize( ConfigFile, ReGridFile, OutputFile, debugLevel, writeRestart, rc=rc )
   if (ESMF_LogFoundError(rc, msg=ESMF_LOGERR_PASSTHRU, &
     line=__LINE__,  &
     file=__FILE__)) &

--- a/src/nexus_methods_mod.F90
+++ b/src/nexus_methods_mod.F90
@@ -22,6 +22,7 @@ module NEXUS_Methods_Mod
   logical :: do_Regrid = .false.
   logical :: do_Debug  = .false.
   logical :: do_NEXUS  = .false.
+  logical :: alwaysWriteRestartFile = .false.
 
 
   ! Default values for HEMCO input files: contain definitions of
@@ -96,7 +97,7 @@ module NEXUS_Methods_Mod
 
 contains
 
-  subroutine Init( ConfigFile, ReGridFile, OutputFile, debugLevel, rc )
+  subroutine Init( ConfigFile, ReGridFile, OutputFile, debugLevel, writeRestart, rc )
 
     use HCO_Config_Mod,    only : Config_ReadFile
     use HCO_State_Mod,     only : HcoState_Init
@@ -108,6 +109,7 @@ contains
     character(len=*),  intent(in)  :: ReGridFile
     character(len=*),  intent(in)  :: OutputFile
     integer,           intent(in)  :: debugLevel
+    logical,           intent(in)  :: writeRestart
     integer, optional, intent(out) :: rc
 
     ! -- local variables
@@ -140,6 +142,7 @@ contains
     do_Regrid = (len_trim(ReGridFile) > 0)
     do_Debug  = (debugLevel > 0)
     do_NEXUS  = (do_Debug .or. do_Regrid)
+    alwaysWriteRestartFile = writeRestart
 
     if (len_trim(OutputFile) > 0) ExptFile = OutputFile
 

--- a/src/nexus_methods_mod.F90
+++ b/src/nexus_methods_mod.F90
@@ -581,6 +581,7 @@ contains
   subroutine Finalize( rc )
 
     use HCO_Driver_Mod,  only : HCO_Final
+    USE HCOIO_DIAGN_MOD, only : HcoDiagn_Write
     use HCOX_Driver_Mod, only : HCOX_Final
     use HCO_State_Mod,   only : HcoState_Final
 
@@ -592,6 +593,14 @@ contains
 
     ! -- begin
     if (present(rc)) rc = ESMF_SUCCESS
+
+    if (do_NEXUS .and. alwaysWriteRestartFile) then
+      call HcoDiagn_Write( HcoState, .TRUE.,  localrc )
+      if (NEXUS_Error_Log(localrc, msg='Error encountered in routine "HcoDiagn_Write"!', &
+         line=__LINE__, &
+         file=__FILE__, &
+         rcToReturn=rc)) return
+    end if
 
     ! Cleanup HCO core
     call HCO_FINAL( HcoState, .FALSE., localrc )


### PR DESCRIPTION
Currently the HEMCO restart file is only written in "non-NEXUS mode", i.e. neither of the `-d` (`NEXUS_Diag.nc` output) or `-r` (regridded `NEXUS_Expt.nc` output) flags used.

This adds an option (off by default) to write out the restart file in NEXUS mode.