### PR TITLE
Debug build for GNU; NEXUS-specific additional flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,21 @@ if(CMAKE_BUILD_TYPE)
   string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
 endif()
 
+# Note HEMCO only support GNU and Intel
+message(STATUS "CMAKE_Fortran_COMPILER_ID: ${CMAKE_Fortran_COMPILER_ID}")
 if(UPPER_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
-  set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -ftrapuv -check all")
+  if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+    set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -ftrapuv -check all")
+  elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_Fortran_FLAGS_DEBUG
+      "${CMAKE_Fortran_FLAGS_DEBUG} \
+-ffpe-trap=invalid,zero,overflow -finit-real=snan \
+-fcheck=all"
+    )
+  endif()
+  message(STATUS "CMAKE_Fortran_FLAGS_DEBUG: ${CMAKE_Fortran_FLAGS_DEBUG}")
+else()
+  message(STATUS "CMAKE_Fortran_FLAGS: ${CMAKE_Fortran_FLAGS}")
 endif()
 
 # add project's subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ if(UPPER_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
   message(STATUS "CMAKE_Fortran_FLAGS_DEBUG: ${CMAKE_Fortran_FLAGS_DEBUG}")
 endif()
 
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+  string(APPEND CMAKE_Fortran_FLAGS " -diag-disable=10448")
+endif()
+
 # add project's subdirectories
 add_subdirectory(HEMCO)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,26 +29,20 @@ set(GCCLASSIC_WRAPPER TRUE)
 if(CMAKE_BUILD_TYPE)
   string(TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
 endif()
+message(STATUS "CMAKE_BUILD_TYPE: '${UPPER_CMAKE_BUILD_TYPE}'")
 
-# Note HEMCO only support GNU and Intel
-message(STATUS "CMAKE_Fortran_COMPILER_ID: ${CMAKE_Fortran_COMPILER_ID}")
 if(UPPER_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+  # HEMCO already sets `-ftrapuv` for Intel and similar options for GNU
+  # https://github.com/geoschem/HEMCO/blob/main/CMakeLists.txt
+  # and its options get applied to NEXUS as well.
+  # Note HEMCO only support GNU and Intel.
   if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-    set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -ftrapuv -check all")
+    set(EXTRA_FLAGS "-check all")
   elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_Fortran_FLAGS_DEBUG
-      "${CMAKE_Fortran_FLAGS_DEBUG} \
--O0 \
--fbacktrace \
--ffpe-trap=invalid,zero,overflow -finit-real=snan \
--fcheck=all \
--Wall -Wextra -Wconversion-extra -Warray-temporaries -Wcharacter-truncation \
-"
-    )
+    set(EXTRA_FLAGS "-fcheck=all")
   endif()
+  set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} ${EXTRA_FLAGS}")
   message(STATUS "CMAKE_Fortran_FLAGS_DEBUG: ${CMAKE_Fortran_FLAGS_DEBUG}")
-else()
-  message(STATUS "CMAKE_Fortran_FLAGS: ${CMAKE_Fortran_FLAGS}")
 endif()
 
 # add project's subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,12 @@ if(UPPER_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
   elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_Fortran_FLAGS_DEBUG
       "${CMAKE_Fortran_FLAGS_DEBUG} \
+-O0 \
+-fbacktrace \
 -ffpe-trap=invalid,zero,overflow -finit-real=snan \
--fcheck=all"
+-fcheck=all \
+-Wall -Wextra -Wconversion-extra -Warray-temporaries -Wcharacter-truncation \
+"
     )
   endif()
   message(STATUS "CMAKE_Fortran_FLAGS_DEBUG: ${CMAKE_Fortran_FLAGS_DEBUG}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,20 @@ set_target_properties(nexus PROPERTIES
 	RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
+# HEMCO sets a lot of flags already, and since they are set as INTERFACE options
+# they are applied to NEXUS as well.
+# https://github.com/geoschem/HEMCO/blob/main/CMakeLists.txt
+# But we can add a few more flags.
+if(UPPER_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+  # Note HEMCO only support GNU and Intel
+  if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    # Note `-Wpedantic` causes fatal warnings in HEMCO build
+    set(EXTRA_FLAGS_NEXUS -Wconversion-extra -Wcharacter-truncation -Wpedantic)
+  endif()
+  target_compile_options(NEXUS_Shared PRIVATE ${EXTRA_FLAGS_NEXUS})
+  target_compile_options(nexus PRIVATE ${EXTRA_FLAGS_NEXUS})
+endif()
+
 install(TARGETS nexus
 	RUNTIME DESTINATION ${RUNDIR}
 )


### PR DESCRIPTION
This change allows `CMAKE_BUILD_TYPE=Debug` to work for GNU as well as Intel.

I also discovered [HEMCO already sets](https://github.com/geoschem/HEMCO/blob/f807e1a3828a57d663001297f8d8cf36978040c3/CMakeLists.txt#L62) `-ftrapuv` for Intel with Debug build type, so I took that one off, as it seems all of HEMCO's compiler flags are automatically applied to NEXUS as well [^1]. I did keep the addition of check-all, since HEMCO doesn't set that. And then I also added some additional debug flags specific to NEXUS.

The build behavior should be the same, except additional checks for non-HEMCO parts of NEXUS, and no longer failing for GNU when `-DCMAKE_BUILD_TYPE=Debug` used.

[^1]: I guess because we are linking `HCOI_Shared` and HEMCO build options are set as `INTERFACE` scoped