### PR TITLE
Remove unnecessary CMAKE_FORTRAN_COMPILER definition from CMakeList.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,6 @@
 # check environment
 cmake_minimum_required(VERSION 3.5)
 
-# set compiler
-if(NOT DEFINED ENV{CMAKE_Fortran_COMPILER})
-  message(FATAL_ERROR "CMAKE_Fortran_COMPILER is not defined")
-endif()
-
-set(CMAKE_Fortran_COMPILER $ENV{CMAKE_Fortran_COMPILER})
-
 # set the project name and version
 project(NEXUS
         VERSION 0.1.0


### PR DESCRIPTION
To resolve the issue #48, the dummy definition `CMAKE_FORTRAN_COMPILER` is removed from `CMakeLists.txt`.
Without it, nexus is compiled successfully on Hera, Orion, Hercules, and Derecho.