### PR TITLE
Update HEMCO version to 3.10.0

### DIFF
--- a/src/nuopc/cap.F90
+++ b/src/nuopc/cap.F90
@@ -944,7 +944,8 @@ contains
     character(len=255)    :: LOC
     character(len=  1)    :: COL
     character(len=255)    :: MyGridFile, ThisLoc
-    character(len=4095)   :: DUM,        ErrMsg,  Msg
+    character(len=5500)   :: DUM
+    character(len=255)    :: ErrMsg, Msg
 
     !=================================================================
     ! SET_GRID begins here

--- a/src/nuopc/cap.F90
+++ b/src/nuopc/cap.F90
@@ -1710,7 +1710,7 @@ contains
       end if
     end if
 
-    !%%%%% Air and skin temperature %%%%%
+    !%%%%% Air temperature %%%%%
     if ( ExtState%T2M%DoUse ) then
       Name = 'T2M'
       call ExtDat_Set( HcoState,     ExtState%T2M,                          &
@@ -1724,10 +1724,25 @@ contains
       end if
     end if
 
+    !%%%%% Skin temperature %%%%%
     if ( ExtState%TSKIN%DoUse ) then
       Name = 'TS'
       call ExtDat_Set( HcoState,     ExtState%TSKIN,                        &
         trim( Name ), RC,       FIRST=FIRST                 )
+      if ( RC /= HCO_SUCCESS ) then
+        ErrMsg = 'Could not find quantity "' // trim( Name )            // &
+          '" for the HEMCO standalone simulation!'
+        call HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
+        call HCO_Leave( HcoState%Config%Err, RC )
+        return
+      end if
+    end if
+
+    !%%%%% Soil temperature %%%%%
+    IF ( ExtState%TSOIL1%DoUse ) THEN
+      Name = 'TSOIL1'
+      CALL ExtDat_Set( HcoState,     ExtState%TSOIL1,                       &
+      trim( Name ), RC,       FIRST=FIRST                 )
       if ( RC /= HCO_SUCCESS ) then
         ErrMsg = 'Could not find quantity "' // trim( Name )            // &
           '" for the HEMCO standalone simulation!'


### PR DESCRIPTION
* Update HEMCO ref to [`deaa192`](https://github.com/geoschem/HEMCO/tree/deaa192)
  - This is [v3.10.0](https://github.com/geoschem/HEMCO/releases/tag/3.10.0) (8 Nov 2024, the latest GitHub release)
* Previous version was 3.6.2 (`4e81881`; #32) although #56 today mistakenly reverted it to 3.4.0 (`4a66bae`; #9) (my bad)
  - Compare: https://github.com/geoschem/HEMCO/compare/3.6.2...3.10.0
* Main change to the code is to make `TSOIL1` available to ExtState for the new soil NOx option