### PR TITLE
Use diag `cName`s for NUOPC field dict entry keys

### DIFF
--- a/src/nuopc/cap.F90
+++ b/src/nuopc/cap.F90
@@ -168,7 +168,7 @@ contains
         name, long_name, units
 
       ! Add to field dictionary
-      call NUOPC_FieldDictionaryAddEntry(long_name, units, rc=rc)
+      call NUOPC_FieldDictionaryAddEntry(name, units, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, &
         file=__FILE__, &
@@ -177,7 +177,7 @@ contains
       ! Advertise field
       call NUOPC_Advertise(exportState, &
         name=name, &
-        StandardName=long_name, &
+        StandardName=name, &
         LongName=long_name, &
         Units=units, &
         rc=rc)

--- a/src/nuopc/cap.F90
+++ b/src/nuopc/cap.F90
@@ -171,15 +171,15 @@ contains
       call NUOPC_FieldDictionaryAddEntry(long_name, units, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, &
-        file=__FILE__,  &
+        file=__FILE__, &
         rcToReturn=rc)) return  ! bail out
 
       ! Advertise field
       call NUOPC_Advertise(exportState, &
-        name = name, &
-        StandardName = long_name, &
-        LongName = long_name, &
-        Units = units, &
+        name=name, &
+        StandardName=long_name, &
+        LongName=long_name, &
+        Units=units, &
         rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, &


### PR DESCRIPTION
Resolves #67 

This is a quick fix, eventually we'll probably need a real `standard_name` approach, which is what the keys [are supposed to be](https://earthsystemmodeling.org/docs/release/ESMF_8_3_1/NUOPC_refdoc/node4.html#SECTION00047100000000000000).