### PR TITLE
HEMCO 3.9.1

### DIFF
--- a/src/nuopc/cap.F90
+++ b/src/nuopc/cap.F90
@@ -1739,20 +1739,6 @@ contains
       end if
     end if
 
-    !%%%%% Soil temperature %%%%%
-    IF ( ExtState%TSOIL1%DoUse ) THEN
-      Name = 'TSOIL1'
-      CALL ExtDat_Set( HcoState,     ExtState%TSOIL1,                       &
-      trim( Name ), RC,       FIRST=FIRST                 )
-      if ( RC /= HCO_SUCCESS ) then
-        ErrMsg = 'Could not find quantity "' // trim( Name )            // &
-          '" for the HEMCO standalone simulation!'
-        call HCO_Error( HcoConfig%Err, ErrMsg, RC, ThisLoc )
-        call HCO_Leave( HcoState%Config%Err, RC )
-        return
-      end if
-    end if
-
     !%%%%% Soil moisture %%%%%
     if ( ExtState%GWETROOT%DoUse ) then
       Name = 'GWETROOT'


### PR DESCRIPTION
This should be temporary but should restore the needed `InvMEGAN_` diagnostics (#69), which were removed in the [HEMCO 3.9.2 release](https://github.com/geoschem/HEMCO/releases/tag/3.9.2).