### PR TITLE
Back to HEMCO 3.6 and fix species limit for core/base

### DIFF
--- a/src/nuopc/cap.F90
+++ b/src/nuopc/cap.F90
@@ -363,7 +363,7 @@ contains
     ! Set Extension number ExtNr to 0, indicating that the core
     ! module shall be executed.
     HcoState%Options%SpcMin = 1
-    HcoState%Options%SpcMax = 2  ! FIXME: nModelSpec
+    HcoState%Options%SpcMax = -1  ! all species above or equal to SpcMin are considered
     HcoState%Options%CatMin = 1
     HcoState%Options%CatMax = -1
     HcoState%Options%ExtNr  = 0


### PR DESCRIPTION
With the species max at 2, all species IDs above that were all zero in the output for diagnostics from base (ext # 0)