### PR TITLE
[Feature] Add GitHub templates for issues and PRs 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "[BUG] "
+labels: bug
+assignees: 'aq-arl'
+---
+
+**Describe the bug**
+<!--A clear and concise description of what the bug is.  -->
+
+**To Reproduce**
+<!--Steps to reproduce the behavior:  -->
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+**Expected behavior**
+<!--A clear and concise description of what you expected to happen. -->
+
+**Platform (please complete the following information):**
+
+- [ ] HERA
+- [ ] WCOSS
+- [ ] GAEA
+- [ ] DERECHO
+- [ ] ORION
+- [ ] HERCULES
+- [ ] HOPPER
+- [ ] ASMD
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex: I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,16 @@
+---
+name: Question
+about: Ask a question or seek clarification
+title: "[QUESTION] "
+labels: question
+assignees: 'aq-arl'
+---
+
+**Question**
+<!-- Clearly state your question or the topic that you need clarification on. -->
+
+**Context**
+<!-- Provide any context or background information that might help answer your question. -->
+
+**Additional Details**
+<!-- Add any additional details or screenshots that might be relevant to your question. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+# Pull Request Template
+
+## Description
+<!-- Provide a brief description of what this PR does, and why it is needed. -->
+
+Fixes # (issue)
+
+## Type of change
+<!-- Please delete options that are not relevant. -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Python files
+- [ ] Module or Library
+- [ ] NUOPC interface issue
+
+## How Has This Been Tested? and what Platform
+<!-- Please describe the tests that you ran to verify your changes. Provide instructions to reproduce and details of your test configuration. -->
+
+### Platform Tested
+
+- [ ] HERA
+- [ ] WCOSS
+- [ ] GAEA
+- [ ] DERECHO
+- [ ] ORION
+- [ ] HERCULES
+- [ ] HOPPER
+- [ ] ASMD
+
+## Checklist:
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## Additional Context
+<!-- Add any other context or screenshots about the pull request here. -->


### PR DESCRIPTION
This PR adds new templates for GitHub issues.

Includes templates for 
- Bug reporting
- Feature Requests 
- Questions 
- PRs 

needs https://github.com/noaa-oar-arl/NEXUS/pull/82 to go first 