### PR TITLE
Add full build support for Derecho

### DIFF
--- a/modulefiles/nexus_derecho.intel.lua
+++ b/modulefiles/nexus_derecho.intel.lua
@@ -3,9 +3,8 @@ loads NEXUS Model prerequisites for NOAA Parallelworks/Intel
 ]])
 
 setenv("LMOD_TMOD_FIND_FIRST","yes")
-prepend_path("MODULEPATH", "/lustre/desc1/scratch/epicufsrt/contrib/modulefiles_extra")
 prepend_path("MODULEPATH", "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
-prepend_path("MODULEPATH", "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/cray-mpich/8.1.29-4natrhl/gcc/12.2.0")
+prepend_path("MODULEPATH", "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/cray-mpich/8.1.29-3sepg3g/gcc/12.4.0")
 
 unload("ncarcompilers")
 stack_intel_ver=os.getenv("stack_intel_ver") or "2024.2.1"

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -35,6 +35,9 @@ case $(hostname -f) in
   ufe1[0-2]) MACHINE_ID=ursa ;; ### ursa10-12
   uecflow01) MACHINE_ID=ursa ;; ### ursaecflow01
 
+  derecho[1-8].hsn.de.hpc.ucar.edu) MACHINE_ID=derecho ;; ### derecho1-8
+  dec*) MACHINE_ID=derecho ;; ### derech compute node
+
   s4-submit.ssec.wisc.edu) MACHINE_ID=s4 ;; ### s4
 
   fe[1-8]) MACHINE_ID=jet ;; ### jet01-8

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -89,6 +89,13 @@ elif [[ $MACHINE_ID = discover* ]]; then
     export PATH=$PATH:$SPACK_ROOT/bin
     . $SPACK_ROOT/share/spack/setup-env.sh
 
+elif [[ ${MACHINE_ID} = derecho ]]; then
+    # We are on NSF NCAR Derecho
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /glade/u/apps/derecho/24.12/spack/opt/spack/lmod/8.7.37/gcc/12.4.0/nr3e/lmod/lmod/init/bash
+    fi
+    module --force purge
+
 elif [[ $MACHINE_ID = noaacloud* ]]; then
     # We are on NOAA Cloud
     module purge


### PR DESCRIPTION
## Description
Updates detect_machine and module-setup to recognize Derecho and prepare the lmod environment properly as is done for other machines. Before this, module files existed but the environment would've had to be created manually.

Also updates the mpich module path to one that exists.

Fixes #104 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Module or Library

## How Has This Been Tested? and what Platform
- Build on Derecho login node (Intel)
- Build on Derecho compute node (Intel)

### Platform Tested

- [ ] HERA
- [ ] WCOSS
- [ ] GAEA
- [x] DERECHO
- [ ] ORION
- [ ] HERCULES
- [ ] HOPPER
- [ ] ASMD

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Context
Part of the global-workflow port to Derecho.