### PR TITLE
Support mixed time units for the GFS data extraction scripts

### DIFF
--- a/utils/python/nexus_gfs_bio.py
+++ b/utils/python/nexus_gfs_bio.py
@@ -255,7 +255,6 @@ def main(i_fps, o_fp):
             # TODO: should move this up and here check that these are same for all files
             gfs_lon_1d = ds["grid_xt"][:]
             gfs_lat_1d = ds["grid_yt"][:]
-            gfs_time_units = ds["time"].units
             gfs_time_calendar = ds["time"].calendar
             gfs_time_dtype = ds["time"].dtype
 
@@ -358,10 +357,10 @@ def main(i_fps, o_fp):
     # Time interpolation of data vars and set times
     #
 
+    gfs_time_units = gfs_times[0].strftime(r"hours since %Y-%m-%d %H:%M:%S")
     gfs_times_num = nc.date2num(gfs_times, units=gfs_time_units, calendar=gfs_time_calendar)
     gfs_is_hourly = (np.diff(gfs_times_num) == 1).all()
     assert (np.floor(gfs_times_num) == gfs_times_num).all(), "on the hour"
-    assert gfs_time_units.startswith("hours since ")
 
     m2_times_num = np.arange(gfs_times_num[0], gfs_times_num[-1] + 1, 1, dtype=gfs_times_num.dtype)
     assert m2_times_num.size == ntime_m2

--- a/utils/python/nexus_gfs_bio.py
+++ b/utils/python/nexus_gfs_bio.py
@@ -238,6 +238,7 @@ def main(i_fps, o_fp):
     # Get GFS file times and grid
     #
 
+    print("Reading times")
     gfs_times = []
     for i, fp in enumerate(files):
         ds = nc.Dataset(fp, "r")
@@ -247,7 +248,7 @@ def main(i_fps, o_fp):
         t_num = ds["time"][0]
         t = nc.num2date(t_num, units=ds["time"].units, calendar=ds["time"].calendar)
         gfs_times.append(t)
-        print(t_num, t, fp)
+        print(t, fp)
 
         # Get grid
         if i == 0:
@@ -362,7 +363,7 @@ def main(i_fps, o_fp):
     assert (np.floor(gfs_times_num) == gfs_times_num).all(), "on the hour"
     assert gfs_time_units.startswith("hours since ")
 
-    m2_times_num = np.arange(gfs_times_num[0], gfs_times_num[-1] + 1, 1, dtype=gfs_time_dtype)
+    m2_times_num = np.arange(gfs_times_num[0], gfs_times_num[-1] + 1, 1, dtype=gfs_times_num.dtype)
     assert m2_times_num.size == ntime_m2
 
     time[:] = m2_times_num
@@ -379,6 +380,9 @@ def main(i_fps, o_fp):
             "(but the GFS input is already hourly, so we won't actually do time interp, "
             "just load variables)"
         )
+    else:
+        print(gfs_times_num, gfs_time_units)
+        print("->", m2_times_num)
     for vn in M2_DATA_VAR_INFO:
         print(vn)
         if gfs_is_hourly:

--- a/utils/python/nexus_gfs_bio.py
+++ b/utils/python/nexus_gfs_bio.py
@@ -246,7 +246,7 @@ def main(i_fps, o_fp):
         assert ds.dimensions["time"].size == 1
         t_num = ds["time"][0]
         t = nc.num2date(t_num, units=ds["time"].units, calendar=ds["time"].calendar)
-        gfs_times.append(t_num)
+        gfs_times.append(t)
         print(t_num, t, fp)
 
         # Get grid
@@ -280,7 +280,7 @@ def main(i_fps, o_fp):
         ds_new.setncattr(k, v)
 
     ntime_gfs = len(files)  # e.g. 25 (0:3:72)
-    ntime_m2 = int(gfs_times[-1] - gfs_times[0] + 1)  # e.g. 73 (0:1:72)
+    ntime_m2 = int((gfs_times[-1] - gfs_times[0]).total_seconds() / 3600) + 1  # e.g. 73 (0:1:72)
     # NOTE: ^ assumes GFS times are on the hour
     ds_new.createDimension("time", ntime_m2)
     time = ds_new.createVariable("time", gfs_time_dtype, ("time",))
@@ -357,24 +357,24 @@ def main(i_fps, o_fp):
     # Time interpolation of data vars and set times
     #
 
-    gfs_times = np.array(gfs_times, dtype=gfs_time_dtype)
-    gfs_is_hourly = (np.diff(gfs_times) == 1).all()
-    assert (np.floor(gfs_times) == gfs_times).all(), "on the hour"
+    gfs_times_num = nc.date2num(gfs_times, units=gfs_time_units, calendar=gfs_time_calendar)
+    gfs_is_hourly = (np.diff(gfs_times_num) == 1).all()
+    assert (np.floor(gfs_times_num) == gfs_times_num).all(), "on the hour"
     assert gfs_time_units.startswith("hours since ")
 
-    m2_times = np.arange(gfs_times[0], gfs_times[-1] + 1, 1, dtype=gfs_time_dtype)
-    assert m2_times.size == ntime_m2
+    m2_times_num = np.arange(gfs_times_num[0], gfs_times_num[-1] + 1, 1, dtype=gfs_time_dtype)
+    assert m2_times_num.size == ntime_m2
 
-    time[:] = m2_times
+    time[:] = m2_times_num
     time.calendar = gfs_time_calendar
     time.units = gfs_time_units
 
-    x = gfs_times
-    x_new = m2_times
+    x = gfs_times_num
+    x_new = m2_times_num
 
     print("Time interp")
     if gfs_is_hourly:
-        assert (gfs_times == m2_times).all()
+        assert (gfs_times_num == m2_times_num).all()
         print(
             "(but the GFS input is already hourly, so we won't actually do time interp, "
             "just load variables)"

--- a/utils/python/nexus_gfs_metemis.py
+++ b/utils/python/nexus_gfs_metemis.py
@@ -165,7 +165,6 @@ def main(i_fps, o_fp):
             # TODO: should move this up and here check that these are same for all files
             gfs_lon_1d = ds["grid_xt"][:]
             gfs_lat_1d = ds["grid_yt"][:]
-            gfs_time_units = ds["time"].units
             gfs_time_calendar = ds["time"].calendar
             gfs_time_dtype = ds["time"].dtype
 
@@ -248,10 +247,10 @@ def main(i_fps, o_fp):
     # Time interpolation of data vars and set times
     #
 
+    gfs_time_units = gfs_times[0].strftime(r"hours since %Y-%m-%d %H:%M:%S")
     gfs_times_num = nc.date2num(gfs_times, units=gfs_time_units, calendar=gfs_time_calendar)
     gfs_is_hourly = (np.diff(gfs_times_num) == 1).all()
     assert (np.floor(gfs_times_num) == gfs_times_num).all(), "on the hour"
-    assert gfs_time_units.startswith("hours since ")
 
     m2_times_num = np.arange(gfs_times_num[0], gfs_times_num[-1] + 1, 1, dtype=gfs_times_num.dtype)
     assert m2_times_num.size == ntime_m2

--- a/utils/python/nexus_gfs_metemis.py
+++ b/utils/python/nexus_gfs_metemis.py
@@ -148,6 +148,7 @@ def main(i_fps, o_fp):
     # Get GFS file times and grid
     #
 
+    print("Reading times")
     gfs_times = []
     for i, fp in enumerate(files):
         ds = nc.Dataset(fp, "r")
@@ -156,8 +157,8 @@ def main(i_fps, o_fp):
         assert ds.dimensions["time"].size == 1
         t_num = ds["time"][0]
         t = nc.num2date(t_num, units=ds["time"].units, calendar=ds["time"].calendar)
-        gfs_times.append(t_num)
-        print(t_num, t, fp)
+        gfs_times.append(t)
+        print(t, fp)
 
         # Get grid
         if i == 0:
@@ -190,7 +191,7 @@ def main(i_fps, o_fp):
         ds_new.setncattr(k, v)
 
     ntime_gfs = len(files)  # e.g. 25 (0:3:72)
-    ntime_m2 = int(gfs_times[-1] - gfs_times[0] + 1)  # e.g. 73 (0:1:72)
+    ntime_m2 = int((gfs_times[-1] - gfs_times[0]).total_seconds() / 3600) + 1  # e.g. 73 (0:1:72)
     # NOTE: ^ assumes GFS times are on the hour
     ds_new.createDimension("time", ntime_m2)
     time = ds_new.createVariable("time", gfs_time_dtype, ("time",))
@@ -247,28 +248,31 @@ def main(i_fps, o_fp):
     # Time interpolation of data vars and set times
     #
 
-    gfs_times = np.array(gfs_times, dtype=gfs_time_dtype)
-    gfs_is_hourly = (np.diff(gfs_times) == 1).all()
-    assert (np.floor(gfs_times) == gfs_times).all(), "on the hour"
+    gfs_times_num = nc.date2num(gfs_times, units=gfs_time_units, calendar=gfs_time_calendar)
+    gfs_is_hourly = (np.diff(gfs_times_num) == 1).all()
+    assert (np.floor(gfs_times_num) == gfs_times_num).all(), "on the hour"
     assert gfs_time_units.startswith("hours since ")
 
-    m2_times = np.arange(gfs_times[0], gfs_times[-1] + 1, 1, dtype=gfs_time_dtype)
-    assert m2_times.size == ntime_m2
+    m2_times_num = np.arange(gfs_times_num[0], gfs_times_num[-1] + 1, 1, dtype=gfs_times_num.dtype)
+    assert m2_times_num.size == ntime_m2
 
-    time[:] = m2_times
+    time[:] = m2_times_num
     time.calendar = gfs_time_calendar
     time.units = gfs_time_units
 
-    x = gfs_times
-    x_new = m2_times
+    x = gfs_times_num
+    x_new = m2_times_num
 
     print("Time interp")
     if gfs_is_hourly:
-        assert (gfs_times == m2_times).all()
+        assert (gfs_times_num == m2_times_num).all()
         print(
             "(but the GFS input is already hourly, so we won't actually do time interp, "
             "just load variables)"
         )
+    else:
+        print(gfs_times_num, gfs_time_units)
+        print("->", m2_times_num)
     for vn in M2_DATA_VAR_INFO:
         print(vn)
         if gfs_is_hourly:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of what this PR does, and why it is needed. -->

Support mixed time units when reading times and determining the time interp target for the GFS data extraction scripts.

cc: @KaiWang-NOAA @drnimbusrain 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Python files
- [ ] Module or Library
- [ ] NUOPC interface issue

## How Has This Been Tested? and what Platform
<!-- Please describe the tests that you ran to verify your changes. Provide instructions to reproduce and details of your test configuration. -->

Script tested on Gaea C6 like so:
```sh
./utils/python/nexus_gfs_bio.py -i /gpfs/f6/drsa-fire2/world-shared/Kai.Wang/temp/gfs.20260301/00/model/atmos/history/gfs.t00z.sfc.f*.nc
```
:point_up: 3-hourly :point_down: hourly
```sh
./utils/python/nexus_gfs_bio.py -i /gpfs/f6/drsa-fire2/world-shared/Kai.Wang/temp/gfs.20260702/00/model/atmos/history/gfs.t00z.sfc.f*.nc
```

### Platform Tested

- [ ] HERA
- [ ] WCOSS
- [x] GAEA
- [ ] DERECHO
- [ ] ORION
- [ ] HERCULES
- [ ] HOPPER
- [ ] ASMD